### PR TITLE
Add excludedusers parameter. Provide user ID where user's name unavailable.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -122,6 +122,11 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
                     $data[$name][] = $value;
                 }
                 break;
+            case 'excludedusers':
+                foreach(preg_split('/\s*,\s*/', $value) as $value) {
+                    $data[$name][] = $value;
+                }
+                break;
             case 'excludedpages':
                 foreach(preg_split('/\s*,\s*/', $value) as $page) {
                     if(!empty($page)) {
@@ -160,7 +165,7 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
         if($mode == 'xhtml') {
             /* @var Doku_Renderer_xhtml $R */
             $R->info['cache'] = false;
-            $changes = $this->getChanges($data['count'], $data['ns'], $data['excludedpages'], $data['type'], $data['user'], $data['maxage']);
+            $changes = $this->getChanges($data['count'], $data['ns'], $data['excludedpages'], $data['type'], $data['user'], $data['maxage'], $data['excludedusers']);
             if(!count($changes)) return true;
 
             switch($data['render']) {
@@ -193,7 +198,7 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
      * @param int   $maxage
      * @return array
      */
-    protected function getChanges($num, $ns, $excludedpages, $type, $user, $maxage) {
+    protected function getChanges($num, $ns, $excludedpages, $type, $user, $maxage, $excludedusers) {
         global $conf;
         $changes = array();
         $seen = array();
@@ -213,7 +218,7 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
         if(is_null($maxage)) $maxage = (int) $this->getConf('maxage');
 
         for($i = count($lines) - 1; $i >= 0; $i--) {
-            $change = $this->handleChangelogLine($lines[$i], $ns, $excludedpages, $type, $user, $maxage, $seen);
+            $change = $this->handleChangelogLine($lines[$i], $ns, $excludedpages, $type, $user, $maxage, $seen, $excludedusers);
             if($change !== false) {
                 $changes[] = $change;
                 // break when we have enough entries
@@ -245,7 +250,7 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
      * @param array  $seen
      * @return array|bool
      */
-    protected function handleChangelogLine($line, $ns, $excludedpages, $type, $user, $maxage, &$seen) {
+    protected function handleChangelogLine($line, $ns, $excludedpages, $type, $user, $maxage, &$seen, $excludedusers) {
         // split the line into parts
         $change = parseChangelogLine($line);
         if($change === false) return false;
@@ -286,6 +291,13 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
         if(!empty($excludedpages)) {
             foreach($excludedpages as $page) {
                 if($change['id'] == $page) return false;
+            }
+        }
+
+        // exclude users
+        if(!empty($excludedusers)) {
+            foreach($excludedusers as $user) {
+                if($change['user'] == $user) return false;
             }
         }
 
@@ -443,10 +455,15 @@ class syntax_plugin_changes extends DokuWiki_Syntax_Plugin {
         global $auth;
         if(!empty($change['user'])) {
             $user = $auth->getUserData($change['user']);
-            return $user['name'];
+            if (empty($user)) {
+                return $change['user'];
+            } else {
+                return $user['name'];
+            }
         } else {
             return $change['ip'];
         }
     }
 }
+
 


### PR DESCRIPTION
 * **excludedusers parameter**: takes a comma-separated list of usernames whose changes will be excluded from the output of this instance of {{changes}}.
* **Provide user ID where username unavailable**. Under some auth environments, the descriptive username (e.g. "Jane User") is unavailable. Provide the user's login ID instead ("jane.user") instead of "". For example, in a corporate environment, an AD server may be used for authentication which does not provide the descriptive name of the user, and this may be outside the control of the wiki administrator.